### PR TITLE
Owncast add test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -326,6 +326,7 @@ in
   openstack-image-metadata = (handleTestOn ["x86_64-linux"] ./openstack-image.nix {}).metadata or {};
   openstack-image-userdata = (handleTestOn ["x86_64-linux"] ./openstack-image.nix {}).userdata or {};
   opentabletdriver = handleTest ./opentabletdriver.nix {};
+  owncast = handleTest ./owncast.nix {};
   image-contents = handleTest ./image-contents.nix {};
   orangefs = handleTest ./orangefs.nix {};
   os-prober = handleTestOn ["x86_64-linux"] ./os-prober.nix {};

--- a/nixos/tests/owncast.nix
+++ b/nixos/tests/owncast.nix
@@ -1,0 +1,21 @@
+{ system ? builtins.currentSystem, config ? { }
+, pkgs ? import ../.. { inherit system config; } }:
+
+with import (nixpkgs + "/nixos/lib/testing-python.nix") { inherit system; };
+makeTest {
+  name = "owncast";
+  meta = with pkgs.stdenv.lib.maintainers; { maintainers = [ MayNiklas ]; };
+
+  nodes = {
+    client = { ... }: {
+      environment.systemPackages = [ curl ];
+      services.owncast = { enable = true; };
+    };
+  };
+
+  testScript = ''
+    start_all()
+    client.wait_for_unit("owncast.service")
+    client.succeed("curl localhost:8080/api/status")
+  '';
+}

--- a/pkgs/servers/owncast/default.nix
+++ b/pkgs/servers/owncast/default.nix
@@ -1,4 +1,5 @@
-{ lib, buildGoModule, fetchFromGitHub, bash, which, ffmpeg, makeWrapper, ... }:
+{ lib, buildGoModule, fetchFromGitHub, nixosTests, bash, which, ffmpeg
+, makeWrapper, ... }:
 
 buildGoModule rec {
 
@@ -45,6 +46,8 @@ buildGoModule rec {
     $out/bin/owncast --help
     runHook postCheck
   '';
+
+  passthru.tests.owncast = nixosTests.testOwncast;
 
   meta = with lib; {
     description = "self-hosted video live streaming solution";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
